### PR TITLE
fix: list object not show removed objects

### DIFF
--- a/cmd/cmd_object.go
+++ b/cmd/cmd_object.go
@@ -546,7 +546,9 @@ func listObjects(ctx *cli.Context) error {
 			return nil
 		}
 		info := object.ObjectInfo
-		fmt.Printf("object name: %s , object id:%s, object status:%s \n", info.ObjectName, info.Id, info.ObjectStatus)
+		if !object.Removed {
+			fmt.Printf("object name: %s , object id:%s, object status:%s \n", info.ObjectName, info.Id, info.ObjectStatus)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Description

ls commands shoul not show removed objects 

### Rationale

the removed objects should not be listed

### Example
NA

### Changes

Notable changes:
* NA
* ...
