### PR TITLE
feat: improve sp command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ gnfd-cmd sp ls
 // get storage provider info
 gnfd-cmd sp head https://gnfd-testnet-sp-1.nodereal.io
 
-// get quota price of storage provider:
+// get quota and storage price of storage provider:
 gnfd-cmd sp get-price https://gnfd-testnet-sp-1.nodereal.io
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ THis command is used to list the SP and query the information of SP.
 gnfd-cmd sp ls
 
 // get storage provider info
-gnfd-cmd sp head --spEndpoint https://gnfd-testnet-sp-1.nodereal.io
+gnfd-cmd sp head https://gnfd-testnet-sp-1.nodereal.io
 
 // get quota price of storage provider:
-gnfd-cmd sp get-price --spAddress 0x70d1983A9A76C8d5d80c4cC13A801dc570890819
+gnfd-cmd sp get-price https://gnfd-testnet-sp-1.nodereal.io
 ```
 
 #### Bucket Operations

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -45,13 +45,10 @@ const (
 	removeMemberFlag = "removeMembers"
 	groupOwnerFlag   = "groupOwner"
 	headMemberFlag   = "headMember"
-	spAddressFlag    = "spAddress"
-	spEndpointFlag   = "spEndpoint"
 	groupIDFlag      = "groupId"
 	granteeFlag      = "grantee"
 	actionsFlag      = "actions"
 	effectFlag       = "effect"
-	userAddressFlag  = "user"
 	expireTimeFlag   = "expire"
 
 	ownerAddressFlag = "owner"


### PR DESCRIPTION
### Description

no need pass flag for sp query command

### Rationale

more convenient for user

### Example

```
// get storage provider info
gnfd-cmd sp head https://gnfd-testnet-sp-1.nodereal.io

// get quota price of storage provider:
gnfd-cmd sp get-price https://gnfd-testnet-sp-1.nodereal.io

```
### Changes

Notable changes:
*  no need to pass --SPaddress
