### PR TITLE
fix: remove password for query commands

### DIFF
--- a/cmd/client_gnfd.go
+++ b/cmd/client_gnfd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/bnb-chain/greenfield-go-sdk/client"
+	"github.com/bnb-chain/greenfield-go-sdk/types"
 	sdktypes "github.com/bnb-chain/greenfield-go-sdk/types"
 	"github.com/urfave/cli/v2"
 )
@@ -32,16 +33,23 @@ func showVersion(ctx *cli.Context) error {
 }
 
 // NewClient returns a new greenfield client
-func NewClient(ctx *cli.Context) (client.Client, error) {
-	privateKey, _, err := parseKeystore(ctx)
-	if err != nil {
-		return nil, err
-	}
+func NewClient(ctx *cli.Context, isQueryCmd bool) (client.Client, error) {
+	var (
+		account    *types.Account
+		err        error
+		privateKey string
+	)
+	if isQueryCmd {
+		privateKey, _, err = parseKeystore(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-	account, err := sdktypes.NewAccountFromPrivateKey("gnfd-account", privateKey)
-	if err != nil {
-		fmt.Println("new account err", err.Error())
-		return nil, err
+		account, err = sdktypes.NewAccountFromPrivateKey("gnfd-account", privateKey)
+		if err != nil {
+			fmt.Println("new account err", err.Error())
+			return nil, err
+		}
 	}
 
 	rpcAddr, chainId, host, err := getConfig(ctx)
@@ -50,7 +58,6 @@ func NewClient(ctx *cli.Context) (client.Client, error) {
 	}
 
 	var cli client.Client
-
 	if host != "" {
 		cli, err = client.New(chainId, rpcAddr, client.Option{DefaultAccount: account, Host: host})
 	} else {

--- a/cmd/cmd_account.go
+++ b/cmd/cmd_account.go
@@ -110,7 +110,7 @@ $ gnfd-cmd bank balance --address 0x... `,
 }
 
 func getAccountBalance(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -355,7 +355,7 @@ func createAccount(ctx *cli.Context) error {
 }
 
 func Bridge(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -388,7 +388,7 @@ func Bridge(ctx *cli.Context) error {
 }
 
 func Transfer(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_bucket.go
+++ b/cmd/cmd_bucket.go
@@ -147,7 +147,7 @@ func createBucket(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -203,7 +203,7 @@ func updateBucket(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -263,7 +263,7 @@ func updateBucket(ctx *cli.Context) error {
 
 // listBuckets list the buckets of the specific owner
 func listBuckets(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -294,7 +294,7 @@ func listBuckets(ctx *cli.Context) error {
 }
 
 func mirrorBucket(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_delete.go
+++ b/cmd/cmd_delete.go
@@ -66,7 +66,7 @@ func deleteBucket(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -106,7 +106,7 @@ func deleteObject(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -145,7 +145,7 @@ func deleteGroup(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_group.go
+++ b/cmd/cmd_group.go
@@ -109,7 +109,7 @@ func createGroup(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -160,7 +160,7 @@ func updateGroupMember(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -231,7 +231,7 @@ func getGroupOwner(ctx *cli.Context, client client.Client) (string, error) {
 }
 
 func mirrorGroup(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_hash.go
+++ b/cmd/cmd_hash.go
@@ -39,7 +39,7 @@ func computeHashRoot(ctx *cli.Context) error {
 		return errors.New("file size should less than 5G")
 	}
 
-	gnfdClient, err := NewClient(ctx)
+	gnfdClient, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_head.go
+++ b/cmd/cmd_head.go
@@ -86,7 +86,7 @@ func headObject(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -109,7 +109,7 @@ func headBucket(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -133,7 +133,7 @@ func headGroup(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -168,7 +168,7 @@ func headGroupMember(ctx *cli.Context) error {
 	headMember := ctx.Args().Get(0)
 	groupName := ctx.Args().Get(1)
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_object.go
+++ b/cmd/cmd_object.go
@@ -281,7 +281,7 @@ func putObject(ctx *cli.Context) error {
 		objectName = filepath.Base(filePath)
 	}
 
-	gnfdClient, err := NewClient(ctx)
+	gnfdClient, err := NewClient(ctx, false)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func getObject(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	gnfdClient, err := NewClient(ctx)
+	gnfdClient, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -470,7 +470,7 @@ func cancelCreateObject(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	cli, err := NewClient(ctx)
+	cli, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -502,7 +502,7 @@ func listObjects(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -551,7 +551,7 @@ func createFolder(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -596,7 +596,7 @@ func updateObject(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -646,7 +646,7 @@ func getUploadInfo(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -688,7 +688,7 @@ func getObjAndBucketNames(urlInfo string) (string, string, error) {
 }
 
 func mirrorObject(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_payment.go
+++ b/cmd/cmd_payment.go
@@ -53,7 +53,7 @@ func buyQuotaForBucket(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -90,7 +90,7 @@ func getQuotaInfo(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_paymentAccount.go
+++ b/cmd/cmd_paymentAccount.go
@@ -28,7 +28,7 @@ $ gnfd-cmd payment-account create`,
 }
 
 func CreatePaymentAccount(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -81,7 +81,7 @@ $ gnfd-cmd payment-account deposit --toAddress 0x.. --amount 12345`,
 }
 
 func Deposit(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -141,7 +141,7 @@ $ gnfd-cmd payment-account withdraw --fromAddress 0x.. --amount 12345`,
 }
 
 func Withdraw(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -196,7 +196,7 @@ $ gnfd-cmd payment-account ls `,
 }
 
 func listPaymentAccounts(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_policy.go
+++ b/cmd/cmd_policy.go
@@ -163,7 +163,7 @@ func deletePolicy(ctx *cli.Context) error {
 }
 
 func handlePutPolicy(ctx *cli.Context, resource string, statements []*permTypes.Statement, policyType ResourceType) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func handlePutPolicy(ctx *cli.Context, resource string, statements []*permTypes.
 }
 
 func handleDeletePolicy(ctx *cli.Context, resource string, policyType ResourceType) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd_sp.go
+++ b/cmd/cmd_sp.go
@@ -53,7 +53,7 @@ $ gnfd-cmd sp get-price https://gnfd-testnet-sp-1.nodereal.io`,
 }
 
 func ListSP(ctx *cli.Context) error {
-	client, err := NewClient(ctx, false)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -125,7 +125,7 @@ func getQuotaPrice(ctx *cli.Context) error {
 	}
 	endpoint := ctx.Args().Get(0)
 
-	client, err := NewClient(ctx, false)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/cmd_sp.go
+++ b/cmd/cmd_sp.go
@@ -53,7 +53,7 @@ $ gnfd-cmd sp get-price https://gnfd-testnet-sp-1.nodereal.io`,
 }
 
 func ListSP(ctx *cli.Context) error {
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -81,7 +81,7 @@ func querySP(ctx *cli.Context) error {
 	}
 	endpoint := ctx.Args().Get(0)
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -125,7 +125,7 @@ func getQuotaPrice(ctx *cli.Context) error {
 	}
 	endpoint := ctx.Args().Get(0)
 
-	client, err := NewClient(ctx)
+	client, err := NewClient(ctx, false)
 	if err != nil {
 		return toCmdErr(err)
 	}


### PR DESCRIPTION
### Description

remove password input requirement for query commands , including:
```
“bucket/object/group/group-member head”
“sp ls/query/get-price"
“payment-account ls”
"bank balance"
```

### Rationale

improve command usage and optimize user experience.

### Example
NA

### Changes

Notable changes:
* remove password for query commands 
