### PR TITLE
fix: fix group owner logic

### DIFF
--- a/cmd/cmd_head.go
+++ b/cmd/cmd_head.go
@@ -141,7 +141,7 @@ func headGroup(ctx *cli.Context) error {
 	c, cancelHeadGroup := context.WithCancel(globalContext)
 	defer cancelHeadGroup()
 
-	groupOwner, err := getGroupOwner(ctx, client)
+	groupOwner, err := getGroupOwner(ctx)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -176,7 +176,7 @@ func headGroupMember(ctx *cli.Context) error {
 	c, cancelHeadBucket := context.WithCancel(globalContext)
 	defer cancelHeadBucket()
 
-	groupOwner, err := getGroupOwner(ctx, client)
+	groupOwner, err := getGroupOwner(ctx)
 	if err != nil {
 		return toCmdErr(err)
 	}


### PR DESCRIPTION
### Description

At present, the group owner is obtained from the client.GetDefaultAccount() interface, but this interface must provide a private key, and the query interface such as head groupmember does not provide a private key, and a panic will occur. The repair method is to obtain it from the keystore user's address

### Rationale

avoid panic error when get Group owner

### Example
NA

### Changes

Notable changes:
* add each change in a bullet point here
* ...
