### PR TITLE
fix: fix get default account err

### DIFF
--- a/cmd/cmd_account.go
+++ b/cmd/cmd_account.go
@@ -118,20 +118,9 @@ func getAccountBalance(ctx *cli.Context) error {
 	c, cancelCreateBucket := context.WithCancel(globalContext)
 	defer cancelCreateBucket()
 
-	var addr string
-	flagAddr := ctx.String(addressFlag)
-	if flagAddr != "" {
-		_, err = sdk.AccAddressFromHexUnsafe(flagAddr)
-		if err != nil {
-			return toCmdErr(err)
-		}
-		addr = flagAddr
-	} else {
-		acct, err := client.GetDefaultAccount()
-		if err != nil {
-			return toCmdErr(err)
-		}
-		addr = acct.GetAddress().String()
+	addr, err := getUserAddress(ctx)
+	if err != nil {
+		return err
 	}
 
 	resp, err := client.GetAccountBalance(c, addr)

--- a/cmd/cmd_head.go
+++ b/cmd/cmd_head.go
@@ -141,7 +141,7 @@ func headGroup(ctx *cli.Context) error {
 	c, cancelHeadGroup := context.WithCancel(globalContext)
 	defer cancelHeadGroup()
 
-	groupOwner, err := getGroupOwner(ctx, client)
+	groupOwner, err := getGroupOwner(ctx)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -176,7 +176,7 @@ func headGroupMember(ctx *cli.Context) error {
 	c, cancelHeadBucket := context.WithCancel(globalContext)
 	defer cancelHeadBucket()
 
-	groupOwner, err := getGroupOwner(ctx, client)
+	groupOwner, err := getGroupOwner(ctx)
 	if err != nil {
 		return toCmdErr(err)
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -501,4 +502,29 @@ func getHomeDir(ctx *cli.Context) (string, error) {
 		return ctx.String(homeFlag), nil
 	}
 	return "", errors.New("home flag should not be empty")
+}
+
+func getUserAddress(ctx *cli.Context) (string, error) {
+	var userAddress string
+	var err error
+	flagAddr := ctx.String(addressFlag)
+	if flagAddr != "" {
+		_, err = sdk.AccAddressFromHexUnsafe(flagAddr)
+		if err != nil {
+			return "", toCmdErr(err)
+		}
+		userAddress = flagAddr
+	} else {
+		keyJson, _, err := loadKeyStoreFile(ctx)
+		if err != nil {
+			return "", toCmdErr(err)
+		}
+
+		k := new(encryptedKey)
+		if err = json.Unmarshal(keyJson, k); err != nil {
+			return "", toCmdErr(errors.New("failed to get account info: " + err.Error()))
+		}
+		userAddress = k.Address
+	}
+	return userAddress, nil
 }


### PR DESCRIPTION
### Description

remove the requirement of  setting default account  of get-banlance, head-group, head-group member

### Rationale

improve cmd usage

### Example

NA

### Changes

Notable changes:
* remove the requirement of  setting default account  for querying cmd