### PR TITLE
fix: fix get-quota

### DIFF
--- a/cmd/cmd_payment.go
+++ b/cmd/cmd_payment.go
@@ -110,7 +110,7 @@ func getQuotaInfo(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	fmt.Printf("quota info:\n charged quota:%d \n free quota:%d \n consumed quota:%d \n",
-		quotaInfo.ReadQuotaSize, quotaInfo.SPFreeReadQuotaSize, quotaInfo.ReadConsumedSize)
+	fmt.Printf("quota info:\n charged quota:%d \n free quota:%d \n consumed quota:%d, free consumed quota: %d \n",
+		quotaInfo.ReadQuotaSize, quotaInfo.SPFreeReadQuotaSize, quotaInfo.ReadConsumedSize, quotaInfo.FreeConsumedSize)
 	return nil
 }

--- a/cmd/cmd_payment.go
+++ b/cmd/cmd_payment.go
@@ -110,7 +110,7 @@ func getQuotaInfo(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	fmt.Printf(" quota info:\n charged quota:%d \n free quota:%d \n consumed charged quota:%d \n consumed free quota: %d \n",
+	fmt.Printf(" quota info:\n charged quota:%d \n free quota remained :%d \n charged quota consumed:%d \n free quota consumed: %d \n",
 		quotaInfo.ReadQuotaSize, quotaInfo.SPFreeReadQuotaSize, quotaInfo.ReadConsumedSize, quotaInfo.FreeConsumedSize)
 
 	return nil

--- a/cmd/cmd_payment.go
+++ b/cmd/cmd_payment.go
@@ -110,7 +110,7 @@ func getQuotaInfo(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	fmt.Printf("quota info:\n charged quota:%d \n free quota:%d \n consumed quota:%d, free consumed quota: %d \n",
+	fmt.Printf("quota info:\n charged quota:%d \n free quota:%d \n consumed quota:%d \n free consumed quota: %d \n",
 		quotaInfo.ReadQuotaSize, quotaInfo.SPFreeReadQuotaSize, quotaInfo.ReadConsumedSize, quotaInfo.FreeConsumedSize)
 	return nil
 }

--- a/cmd/cmd_payment.go
+++ b/cmd/cmd_payment.go
@@ -110,7 +110,8 @@ func getQuotaInfo(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	fmt.Printf("quota info:\n charged quota:%d \n free quota:%d \n consumed quota:%d \n free consumed quota: %d \n",
+	fmt.Printf("quota info:\n charged quota:%d \n free quota:%d \n consumed charged quota:%d \n consumed free quota: %d \n",
 		quotaInfo.ReadQuotaSize, quotaInfo.SPFreeReadQuotaSize, quotaInfo.ReadConsumedSize, quotaInfo.FreeConsumedSize)
+
 	return nil
 }

--- a/cmd/cmd_payment.go
+++ b/cmd/cmd_payment.go
@@ -110,7 +110,7 @@ func getQuotaInfo(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	fmt.Printf("quota info:\n charged quota:%d \n free quota:%d \n consumed charged quota:%d \n consumed free quota: %d \n",
+	fmt.Printf(" quota info:\n charged quota:%d \n free quota:%d \n consumed charged quota:%d \n consumed free quota: %d \n",
 		quotaInfo.ReadQuotaSize, quotaInfo.SPFreeReadQuotaSize, quotaInfo.ReadConsumedSize, quotaInfo.FreeConsumedSize)
 
 	return nil


### PR DESCRIPTION
### Description

the return format of SP quota info has changed , 



<img width="1416" alt="image" src="https://github.com/bnb-chain/greenfield-storage-provider/assets/19421226/d7128305-6852-4f3e-9d53-0b9734cdb640">

the quota return of cmd will be :
 quota info:
 charged quota:0
 free quota remained :149942272
 charged quota consumed:0
 free quota consumed: 923799552

### Rationale

tell us why we need these changes...

### Example

<img width="898" alt="image" src="https://github.com/bnb-chain/greenfield-cmd/assets/19421226/e6d55102-7a2a-44ae-b098-913d6d584f53">


### Changes

Notable changes:
* add each change in a bullet point here
* ...
