### PR TITLE
fix: improve get-quota api

### DIFF
--- a/cmd/cmd_payment.go
+++ b/cmd/cmd_payment.go
@@ -110,7 +110,14 @@ func getQuotaInfo(ctx *cli.Context) error {
 		return toCmdErr(err)
 	}
 
-	fmt.Printf("quota info:\n charged quota:%d \n free quota:%d \n consumed quota:%d \n",
-		quotaInfo.ReadQuotaSize, quotaInfo.SPFreeReadQuotaSize, quotaInfo.ReadConsumedSize)
+	nameMaxLen := len("consumed charged quota:")
+	format := fmt.Sprintf("%%-%ds %%-%dd   \n", nameMaxLen, 50)
+	firstLineFormat := fmt.Sprintf("%%-%ds %%-%ds  \n", nameMaxLen, 50)
+	fmt.Printf(firstLineFormat, "quota name", "quota value")
+	fmt.Printf(format, "charged quota:", quotaInfo.ReadQuotaSize)
+	fmt.Printf(format, "remained free quota:", quotaInfo.SPFreeReadQuotaSize)
+	fmt.Printf(format, "consumed charged quota:", quotaInfo.ReadConsumedSize)
+	fmt.Printf(format, "consumed free quota:", quotaInfo.FreeConsumedSize)
+
 	return nil
 }


### PR DESCRIPTION
### Description

prepare a hot fix to fix get-quota comd

### Rationale

fix get-quota cmd

### Example

wayen@c testnet-test %  ./gnfd-cmd bucket get-quota gnfd://dskl1
quota name              quota value
charged quota:          923799552
remained free quota:    0
consumed charged quota: 81007616
consumed free quota:    1073741824

### Changes

Notable changes:
* add each change in a bullet point here
* ...
