### PR TITLE
feat: support resumable download

### DIFF
--- a/cmd/cmd_object.go
+++ b/cmd/cmd_object.go
@@ -56,13 +56,14 @@ $ gnfd-cmd object put --recursive folderName gnfd://bucket-name`,
 				Usage: "set visibility of the object",
 			},
 			&cli.Uint64Flag{
-				Name:  partSizeFlag,
+				Name: partSizeFlag,
+				// the default part size is 32M
 				Value: 32 * 1024 * 1024,
 				Usage: "indicate the resumable upload 's part size, uploading a large file in multiple parts. " +
 					"The part size is an integer multiple of the segment size.",
 			},
 			&cli.BoolFlag{
-				Name:  resumableUploadFlag,
+				Name:  resumableFlag,
 				Value: false,
 				Usage: "indicate whether need to enable resumeable upload. Resumable upload refers to the process of uploading " +
 					"a file in multiple parts, where each part is uploaded separately.This allows the upload to be resumed from " +
@@ -102,13 +103,14 @@ $ gnfd-cmd object get gnfd://gnfd-bucket/gnfd-object  file.txt `,
 				Usage: "end offset info of the download body",
 			},
 			&cli.Uint64Flag{
-				Name:  partSizeFlag,
+				Name: partSizeFlag,
+				// the default part size is 32M
 				Value: 32 * 1024 * 1024,
 				Usage: "indicate the resumable upload 's part size, uploading a large file in multiple parts. " +
 					"The part size is an integer multiple of the segment size.",
 			},
 			&cli.BoolFlag{
-				Name:  resumableDownloadFlag,
+				Name:  resumableFlag,
 				Value: false,
 				Usage: "indicate whether need to enable resumeable download. Resumable download refers to the process of download " +
 					"a file in multiple parts, where each part is downloaded separately.This allows the download to be resumed from " +
@@ -396,7 +398,7 @@ func uploadFile(bucketName, objectName, filePath, urlInfo string, ctx *cli.Conte
 	contentType := ctx.String(contentTypeFlag)
 	secondarySPAccs := ctx.String(secondarySPFlag)
 	partSize := ctx.Uint64(partSizeFlag)
-	resumableUpload := ctx.Bool(resumableUploadFlag)
+	resumableUpload := ctx.Bool(resumableFlag)
 
 	opts := sdktypes.CreateObjectOptions{}
 	if contentType != "" {
@@ -547,7 +549,7 @@ func getObject(ctx *cli.Context) error {
 	startOffset := ctx.Int64(startOffsetFlag)
 	endOffset := ctx.Int64(endOffsetFlag)
 	partSize := ctx.Uint64(partSizeFlag)
-	resumableDownload := ctx.Bool(resumableDownloadFlag)
+	resumableDownload := ctx.Bool(resumableFlag)
 
 	// flag has been set
 	if startOffset != 0 || endOffset != 0 {
@@ -563,7 +565,6 @@ func getObject(ctx *cli.Context) error {
 			return toCmdErr(err)
 		}
 		fmt.Printf("resumable download object %s, the file path is %s \n", objectName, filePath)
-
 	} else {
 		// If file exist, open it in append mode
 		fd, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0660)
@@ -583,7 +584,6 @@ func getObject(ctx *cli.Context) error {
 			return toCmdErr(err)
 		}
 		fmt.Printf("download object %s, the file path is %s, content length:%d \n", objectName, filePath, uint64(info.Size))
-
 	}
 
 	return nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -93,9 +93,8 @@ const (
 	objectNameFlag     = "objectName"
 
 	// resumable download & upload
-	partSizeFlag          = "partSize"
-	resumableUploadFlag   = "resumableUpload"
-	resumableDownloadFlag = "resumableDownload"
+	partSizeFlag  = "partSize"
+	resumableFlag = "resumable"
 
 	operatorAddressLen = 42
 	exitStatus         = "GRACEFUL_EXITING"


### PR DESCRIPTION
### Description

support resumable download  by adding a flag to "object get cmd"


### Rationale

NA

### Example

./gnfd-cmd -c ./config.toml --home ./ object put --resumable --contentType "application/octet-stream" ./File40MB gnfd://spbucket/random_file

<img width="1460" alt="image" src="https://github.com/bnb-chain/greenfield-cmd/assets/11239387/964e16d2-b46a-46ba-a3dc-9c1363b615ae">

./gnfd-cmd -c ./config.toml --home ./ object get --resumable gnfd://spbucket/random_file ./new_random_40mb
<img width="1339" alt="image" src="https://github.com/bnb-chain/greenfield-cmd/assets/11239387/2785f593-47fd-4779-97e1-6652ddc159a8">


### Changes

Notable changes:
* add each change in a bullet point here
* ...
