### PR TITLE
feat: support multi account

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To obtain the latest release, please visit the following URL: https://github.com
 git clone https://github.com/bnb-chain/greenfield-cmd.git
 cd greenfield-cmd
 # Find the latest release here: https://github.com/bnb-chain/greenfield-cmd/releases
-git checkout -b branch-name v0.1.1
+git checkout -b branch-name v1.0.0
 make build
 cd build
 ./gnfd-cmd -h
@@ -97,7 +97,7 @@ Users can use "account import [keyfile]" to generate the keystore.  Before impor
 gnfd-cmd account import key.txt
 ```
 
-The keystore will be generated in the path "keystore/key.json" under the home directory of the system or the directory set by "-home"
+The keystore will be generated in the path "keystore/keyfile" under the home directory of the system or the directory set by "-home"
 and it is also the default path to load keystore when running other commands.
 Password info is also needed to run the command. The terminal will prompt user to enter the password information.
 Users can also specify the password file path by using the "--passwordfile".
@@ -116,6 +116,16 @@ Users can use "account export" or "account ls" to display the keystore informati
 gnfd-cmd account ls
 // export the account key info
 gnfd-cmd account export --unarmoredHex --unsafe
+```
+
+Users can create multiple accounts using the "account import" or "account new" command. You can use the set-default command to specify which account to use for running other commands by default. When executing commands using the default account, there is no need to specify the keystore.
+You can also switch to different accounts for sending requests by specifying the --keystore flag.
+```
+// set the default account.
+gnfd-cmd account set-default [address-info]
+
+// set keystore flag to use other account which is not default
+./gnfd-cmd --keystore /Users/user/.gnfd-cmd/keystore/2023-10-11T09-51-27.868544000Z--xxx  bucket create gnfd://test-bucket
 ```
 
 #### Bank Operations

--- a/cmd/client_gnfd.go
+++ b/cmd/client_gnfd.go
@@ -38,6 +38,7 @@ func NewClient(ctx *cli.Context, isQueryCmd bool) (client.IClient, error) {
 		account    *types.Account
 		err        error
 		privateKey string
+		cli        client.IClient
 	)
 	if !isQueryCmd {
 		privateKey, _, err = parseKeystore(ctx)
@@ -57,7 +58,6 @@ func NewClient(ctx *cli.Context, isQueryCmd bool) (client.IClient, error) {
 		return nil, err
 	}
 
-	var cli client.IClient
 	if host != "" {
 		cli, err = client.New(chainId, rpcAddr, client.Option{DefaultAccount: account, Host: host})
 	} else {

--- a/cmd/cmd_account.go
+++ b/cmd/cmd_account.go
@@ -250,10 +250,11 @@ func importKey(ctx *cli.Context) error {
 	}
 
 	// fetch password content
-	password, err = getPassword(ctx)
+	password, err = getPassword(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}
+	fmt.Println("- You must REMEMBER your password! Without the password, it's impossible to decrypt the key!")
 
 	// encrypt the private key
 	encryptContent, err = EncryptKey(key, password, EncryptScryptN, EncryptScryptP)
@@ -391,7 +392,7 @@ func createAccount(ctx *cli.Context) error {
 	}
 
 	// fetch password content
-	password, err = getPassword(ctx)
+	password, err = getPassword(ctx, true)
 	if err != nil {
 		return toCmdErr(err)
 	}
@@ -524,7 +525,7 @@ func parseKeystore(ctx *cli.Context) (string, string, error) {
 		return "", "", toCmdErr(err)
 	}
 	// fetch password content
-	password, err := getPassword(ctx)
+	password, err := getPassword(ctx, false)
 	if err != nil {
 		return "", "", toCmdErr(err)
 	}

--- a/cmd/cmd_account.go
+++ b/cmd/cmd_account.go
@@ -254,7 +254,6 @@ func importKey(ctx *cli.Context) error {
 	if err != nil {
 		return toCmdErr(err)
 	}
-	fmt.Println("- You must REMEMBER your password! Without the password, it's impossible to decrypt the key!")
 
 	// encrypt the private key
 	encryptContent, err = EncryptKey(key, password, EncryptScryptN, EncryptScryptP)
@@ -274,7 +273,7 @@ func importKey(ctx *cli.Context) error {
 	// if it is the first keystore, set it as the default key
 	checkAndWriteDefaultKey(homeDir, convertAddressToLower(key.Address.String()))
 
-	fmt.Printf("key address: %s, encrypted key file: %s \n", key.Address, keyFilePath)
+	fmt.Printf("imported account: %s, keystore: %s \n", key.Address, keyFilePath)
 	return nil
 }
 
@@ -428,7 +427,7 @@ func createAccount(ctx *cli.Context) error {
 	// if it is the first keystore, set it as the default key
 	checkAndWriteDefaultKey(homeDir, convertAddressToLower(key.Address.String()))
 
-	fmt.Printf("created new account: {%s} \n", account.GetAddress())
+	fmt.Printf("created new account: {%s}, keystore: %s \n", account.GetAddress(), keyFilePath)
 	return nil
 }
 

--- a/cmd/cmd_policy.go
+++ b/cmd/cmd_policy.go
@@ -127,7 +127,7 @@ the resource url can be the follow types:
 3) grn:g:owneraddress:groupname, it indicates the group policy
 
 Examples:
-$ gnfd-cmd policy rm --groupId 111  grn:o::gnfd-bucket/gnfd-object`,
+$ gnfd-cmd policy ls --groupId 111  grn:o::gnfd-bucket/gnfd-object`,
 		Flags: []cli.Flag{
 			&cli.Uint64Flag{
 				Name:  groupIDFlag,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -163,6 +163,7 @@ func main() {
 					cmdListAccount(),
 					cmdCreateAccount(),
 					cmdExportAccount(),
+					cmdSetDefaultAccount(),
 				},
 			},
 			cmdShowVersion(),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,11 +7,16 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
 
 var globalContext, _ = context.WithCancel(context.Background())
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+}
 
 func main() {
 	homeDir, err := os.UserHomeDir()

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -338,7 +338,7 @@ func parseActions(ctx *cli.Context, resourceType ResourceType) ([]permTypes.Acti
 }
 
 // getPassword return the password content
-func getPassword(ctx *cli.Context) (string, error) {
+func getPassword(ctx *cli.Context, needNotice bool) (string, error) {
 	var filepath string
 	if passwordFile := ctx.String(passwordFileFlag); passwordFile != "" {
 		filepath = passwordFile
@@ -350,6 +350,7 @@ func getPassword(ctx *cli.Context) (string, error) {
 	}
 
 	fmt.Print("Please enter the passphrase now:")
+
 	bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		fmt.Println("read password err:", err)
@@ -357,6 +358,10 @@ func getPassword(ctx *cli.Context) (string, error) {
 	}
 	password := string(bytePassword)
 	fmt.Println()
+	if needNotice {
+		fmt.Println("- You must BACKUP your key file! Without the key, it's impossible to set transaction to greenfield!")
+		fmt.Println("- You must REMEMBER your password! Without the password, it's impossible to decrypt the key!")
+	}
 	return password, nil
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -84,12 +84,10 @@ const (
 	BucketResourceType = 2
 	GroupResourceType  = 3
 
-	DefaultConfigPath   = "config/config.toml"
-	DefaultConfigDir    = ".gnfd-cmd"
-	DefaultKeyStorePath = "keystore/key.json"
-	DefaultAccountPath  = "account/defaultKey"
-	DefaultKeyDir       = "keystore"
-	DefaultKeyFile      = "key.json"
+	DefaultConfigPath  = "config/config.toml"
+	DefaultConfigDir   = ".gnfd-cmd"
+	DefaultAccountPath = "account/defaultKey"
+	DefaultKeyDir      = "keystore"
 
 	rpcAddrConfigField = "rpcAddr"
 	chainIdConfigField = "chainId"
@@ -697,5 +695,9 @@ func convertAddressToLower(str string) string {
 		}
 		return r
 	}, str)
-	return converted[2:]
+
+	if strings.HasPrefix(str, "0x") {
+		converted = converted[2:]
+	}
+	return converted
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/bnb-chain/greenfield-go-sdk v1.0.0
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/ethereum/go-ethereum v1.10.26
+	github.com/rs/zerolog v1.29.1
 	github.com/urfave/cli/v2 v2.10.2
 	golang.org/x/term v0.9.0
 )
@@ -25,7 +26,7 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 // indirect
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f // indirect
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228 // indirect
 	github.com/btcsuite/btcd v0.23.3 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.2 // indirect
@@ -107,7 +108,6 @@ require (
 	github.com/prysmaticlabs/prysm v0.0.0-20220124113610-e26cde5e091b // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rjeczalik/notify v0.9.1 // indirect
-	github.com/rs/zerolog v1.29.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,10 +160,12 @@ github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f h1:zJvB2wCd80DQ9Nh/ZNQiP8MrHygSpDoav7OzHyIi/pM=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f/go.mod h1:it3JJVHeG9Wp4QED2GkY/7V9Qo3BuPdoC5/4/U6ecJM=
+github.com/bnb-chain/greenfield-common v0.0.8 h1:OGRXHurdjPhdgAmLzMzNccFvsS0aIb4a/03IuqHYeME=
+github.com/bnb-chain/greenfield-common v0.0.8/go.mod h1:XW4HfxK9D61fLflqfp4OUqtVJuRaf6j8LSygmIs2EAk=
 github.com/bnb-chain/greenfield-cosmos-sdk v1.0.0 h1:hWRvYunA4Um19gwL1SVfMwN9l431ROC7XZ+A5+xM/Bk=
 github.com/bnb-chain/greenfield-cosmos-sdk v1.0.0/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228 h1:WywBaew30hZuqDTOQbkRV3uBg6XHjNIE1s3AXVXbG+8=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228/go.mod h1:K9jK80fbahciC+FAvrch8Qsbw9ZkvVgjfKsqrzPTAVA=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=


### PR DESCRIPTION
### Description

1）support multi-account management

2）support "set-default" command to set the default account with which to send the request

3)  remove debug log printing which print by go-sdk

### Rationale

enhance account management

### Example


```
root@ testnet-test % ./gnfd-cmd account ls
run command error: keystore not exists

root @ testnet-test % ./gnfd-cmd account new
Please enter the passphrase now:
created new account: {0xC7805a0c085c1D96e1BDc5Fcc1F7534982F177EE}

root@testnet-test % ./gnfd-cmd account new
Please enter the passphrase now:
created new account: {0x75345BC9FfFAe09486dE7EC954bAfAEcE29b9b24}

root@testnet-test % ./gnfd-cmd account import key.txt
Please enter the passphrase now:
key address: 0xCEE3823C39Fcc9845D7C7144A836562F37995085, encrypted key file: /Users/user/.gnfd-cmd/keystore/2023-10-11T08-36-54.999924000Z--cee3823c39fcc9845d7c7144a836562f37995085

root@ testnet-test % ./gnfd-cmd account ls
Account: { 0xC7805a0c085c1D96e1BDc5Fcc1F7534982F177EE },  Keystore : /Users/user/.gnfd-cmd/keystore/2023-10-11T08-36-40.926382000Z--c7805a0c085c1d96e1bdc5fcc1f7534982f177ee
Account: { 0x75345BC9FfFAe09486dE7EC954bAfAEcE29b9b24 },  Keystore : /Users/user/.gnfd-cmd/keystore/2023-10-11T08-36-44.626883000Z--75345bc9fffae09486de7ec954bafaece29b9b24
Account: { 0xCEE3823C39Fcc9845D7C7144A836562F37995085 },  Keystore : /Users/user/.gnfd-cmd/keystore/2023-10-11T08-36-54.999924000Z--cee3823c39fcc9845d7c7144a836562f37995085


root@ testnet-test % ./gnfd-cmd account set-default CEE3823C39Fcc9845D7C7144A836562F37995085
the default account has been set to CEE3823C39Fcc9845D7C7144A836562F37995085

```
### Changes

Notable changes:
* add each change in a bullet point here
* ...
