### PR TITLE
fix: fix put bucket policy with object actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1
+BUGFIX
+* [#99](https://github.com/bnb-chain/greenfield-cmd/pull/99) fix put bucket policy with object actions and help info
+
 ## v1.0.0
 FEATURES
 * [#94](https://github.com/bnb-chain/greenfield-cmd/pull/94) support multi-account management and set-default command

--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ The group policy actions can be "update", "delete" or all, update indicates the 
 
 The policy effect can set to be "allow" or "deny" by --effect
 
+If it is an object policy, actions can be the following: create, delete, copy, get, execute, list, update or all. 
+If it is a bucket policy, actions can be the following: delete, update, createObj, deleteObj, copyObj, getObj, executeObj, list or all. The actions which 
+contain Obj means it is an action for the objects in the bucket. If it is a group policy, actions can be the following: update, delete or all.
+
 Put policy examples:
 ```
 // grant object operation permissions to a group

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To obtain the latest release, please visit the following URL: https://github.com
 git clone https://github.com/bnb-chain/greenfield-cmd.git
 cd greenfield-cmd
 # Find the latest release here: https://github.com/bnb-chain/greenfield-cmd/releases
-git checkout -b branch-name v1.0.0
+git checkout -b branch-name v1.0.1
 make build
 cd build
 ./gnfd-cmd -h
@@ -236,15 +236,12 @@ The gnfd-cmd policy command supports the policy for put/delete resources policy(
 
 The principal is need to be set by --grantee which indicates a greenfield account or --groupId which indicates group id.
 
-The object policy action can be "create", "delete", "copy", "get" , "execute", "list" or "all".
-The bucket policy actions can be "update", "delete", "create", "list", "update", "getObj", "createObj" and so on.
-The group policy actions can be "update", "delete" or all, update indicates the update-group-member action.
+The object policy action can be "create", "delete", "copy", "get" , "execute", "list", "update" or "all".
+The bucket policy actions can be "update", "delete",  "list", "update", "createObj", "deleteObj", "copyObj", "getObj", "executeObj" or "all".The actions which
+contain Obj means it is an action for the objects in the bucket.
+The group policy actions can be "update", "delete" or "all".
 
 The policy effect can set to be "allow" or "deny" by --effect
-
-If it is an object policy, actions can be the following: create, delete, copy, get, execute, list, update or all. 
-If it is a bucket policy, actions can be the following: delete, update, createObj, deleteObj, copyObj, getObj, executeObj, list or all. The actions which 
-contain Obj means it is an action for the objects in the bucket. If it is a group policy, actions can be the following: update, delete or all.
 
 Put policy examples:
 ```

--- a/cmd/cmd_group.go
+++ b/cmd/cmd_group.go
@@ -37,7 +37,7 @@ func cmdUpdateGroup() *cli.Command {
 	return &cli.Command{
 		Name:      "update",
 		Action:    updateGroupMember,
-		Usage:     "update group member",
+		Usage:     "add or remove group members",
 		ArgsUsage: "GROUP-NAME",
 		Description: `
 Add or remove group members of the group, you can set add members 

--- a/cmd/cmd_object.go
+++ b/cmd/cmd_object.go
@@ -503,7 +503,7 @@ func uploadFile(bucketName, objectName, filePath, urlInfo string, ctx *cli.Conte
 			return toCmdErr(err)
 		}
 	} else {
-		fmt.Println("resumable uploading is beginning...")
+		fmt.Printf("resumable uploading %s is beginning...\n", objectName)
 		if err = gnfdClient.PutObject(c, bucketName, objectName,
 			objectSize, progressReader, opt); err != nil {
 			return toCmdErr(err)

--- a/cmd/cmd_policy.go
+++ b/cmd/cmd_policy.go
@@ -54,7 +54,7 @@ $ gnfd-cmd policy put --groupId 111 --actions get,delete grn:o::gnfd-bucket/gnfd
 				Value: "",
 				Usage: "set the actions of the policy," +
 					"if it is an object policy, actions can be the following: create, delete, copy, get, execute, list, update or all," +
-					"if it is a bucket policy, actions can be the following: delete, update, deleteObj, copyObj, getObj, executeObj, list or all" +
+					"if it is a bucket policy, actions can be the following: delete, update, create, createObj,deleteObj, copyObj, getObj, executeObj, list or all" +
 					" the actions which contain Obj means it is a action for the objects in the bucket, for example," +
 					" the deleteObj means grant the permission of delete Objects in the bucket" +
 					"if it is a group policy, actions can be the following: update, delete or all, update indicates the update-group-member action" +

--- a/cmd/cmd_policy.go
+++ b/cmd/cmd_policy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bnb-chain/greenfield-go-sdk/pkg/utils"
 	sdktypes "github.com/bnb-chain/greenfield-go-sdk/types"
 	"github.com/bnb-chain/greenfield/sdk/types"
+	gnfdTypes "github.com/bnb-chain/greenfield/types"
 	permTypes "github.com/bnb-chain/greenfield/x/permission/types"
 	"github.com/urfave/cli/v2"
 )
@@ -168,13 +169,18 @@ func putPolicy(ctx *cli.Context) error {
 		}
 	}
 
+	bucketName, err := parseBucketResource(resource)
+	if err != nil {
+		return toCmdErr(err)
+	}
+
 	expireTime := ctx.Uint64(expireTimeFlag)
 	var statement permTypes.Statement
 	if expireTime > 0 {
 		tm := time.Unix(int64(expireTime), 0)
-		statement = utils.NewStatement(actions, effect, nil, sdktypes.NewStatementOptions{StatementExpireTime: &tm})
+		statement = utils.NewStatement(actions, effect, []string{gnfdTypes.NewObjectGRN(bucketName, "*").String()}, sdktypes.NewStatementOptions{StatementExpireTime: &tm})
 	} else {
-		statement = utils.NewStatement(actions, effect, nil, sdktypes.NewStatementOptions{})
+		statement = utils.NewStatement(actions, effect, []string{gnfdTypes.NewObjectGRN(bucketName, "*").String()}, sdktypes.NewStatementOptions{})
 	}
 
 	statements := []*permTypes.Statement{&statement}

--- a/cmd/cmd_policy.go
+++ b/cmd/cmd_policy.go
@@ -55,7 +55,7 @@ $ gnfd-cmd policy put --groupId 111 --actions get,delete grn:o::gnfd-bucket/gnfd
 				Value: "",
 				Usage: "set the actions of the policy," +
 					"if it is an object policy, actions can be the following: create, delete, copy, get, execute, list, update or all," +
-					"if it is a bucket policy, actions can be the following: delete, update, create, createObj,deleteObj, copyObj, getObj, executeObj, list or all" +
+					"if it is a bucket policy, actions can be the following: delete, update, createObj,deleteObj, copyObj, getObj, executeObj, list or all." +
 					" the actions which contain Obj means it is a action for the objects in the bucket, for example," +
 					" the deleteObj means grant the permission of delete Objects in the bucket" +
 					"if it is a group policy, actions can be the following: update, delete or all, update indicates the update-group-member action" +
@@ -164,7 +164,7 @@ func putPolicy(ctx *cli.Context) error {
 		}
 	}
 
-	// if the actions contains object actions of bucket policy, isObjectActionInBucketPolicy will be true
+	// if the actions contain object actions of bucket policy, isObjectActionInBucketPolicy will be set as true
 	actions, isObjectActionInBucketPolicy, err := parseActions(ctx, resourceType)
 	if err != nil {
 		return toCmdErr(err)

--- a/cmd/cmd_policy.go
+++ b/cmd/cmd_policy.go
@@ -55,7 +55,7 @@ $ gnfd-cmd policy put --groupId 111 --actions get,delete grn:o::gnfd-bucket/gnfd
 				Value: "",
 				Usage: "set the actions of the policy," +
 					"if it is an object policy, actions can be the following: create, delete, copy, get, execute, list, update or all," +
-					"if it is a bucket policy, actions can be the following: delete, update, createObj,deleteObj, copyObj, getObj, executeObj, list or all." +
+					"if it is a bucket policy, actions can be the following: delete, update, createObj, deleteObj, copyObj, getObj, executeObj, list or all." +
 					" the actions which contain Obj means it is a action for the objects in the bucket, for example," +
 					" the deleteObj means grant the permission of delete Objects in the bucket" +
 					"if it is a group policy, actions can be the following: update, delete or all, update indicates the update-group-member action" +

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -608,8 +608,8 @@ func (pr *ProgressReader) printProgress() {
 	elapsed := now.Sub(pr.StartTime)
 	uploadSpeed := float64(pr.Current) / elapsed.Seconds()
 
-	if now.Sub(pr.LastPrinted) >= time.Second { // print rate every second
-		progressStr := fmt.Sprintf("uploading progress: %.2f%% [ %s / %s ], rate: %s",
+	if now.Sub(pr.LastPrinted) >= time.Second/2 { // print rate every second
+		progressStr := fmt.Sprintf("uploading progress: %.2f%% [ %s / %s ], rate: %s , cost ",
 			progress, getConvertSize(pr.Current), getConvertSize(pr.Total), getConvertRate(uploadSpeed))
 		// Clear current line
 		fmt.Print("\r", strings.Repeat(" ", len(pr.LastPrintedStr)), "\r")
@@ -643,7 +643,7 @@ func (pw *ProgressWriter) printProgress() {
 	downloadedBytes := pw.Current
 	downloadSpeed := float64(downloadedBytes) / elapsed.Seconds()
 
-	if now.Sub(pw.LastPrinted) >= time.Second { // print rate every second
+	if now.Sub(pw.LastPrinted) >= time.Second/2 { // print rate every second
 		fmt.Printf("\rdownloding progress: %.2f%% [ %s / %s ], rate: %s  ",
 			progress, getConvertSize(pw.Current), getConvertSize(pw.Total), getConvertRate(downloadSpeed))
 		pw.LastPrinted = now

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -245,15 +245,12 @@ func parsePrincipal(grantee string, groupId uint64) (sdktypes.Principal, error) 
 
 	return principal, nil
 }
-
 func getBucketAction(action string) (permTypes.ActionType, bool, error) {
 	switch action {
 	case "update":
 		return permTypes.ACTION_UPDATE_BUCKET_INFO, false, nil
 	case "delete":
 		return permTypes.ACTION_DELETE_BUCKET, false, nil
-	case "create":
-		return permTypes.ACTION_CREATE_OBJECT, false, nil
 	case "list":
 		return permTypes.ACTION_LIST_OBJECT, false, nil
 	case "createObj":

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	Version                 = "v1.0.0"
+	Version                 = "v1.0.1"
 	maxFileSize             = 64 * 1024 * 1024 * 1024
 	maxPutWithoutResumeSize = 2 * 1024 * 1024 * 1024
 	publicReadType          = "public-read"
@@ -110,6 +110,8 @@ const (
 	maxListMemberNum       = 1000
 	progressDelayPrintSize = 10 * 1024 * 1024
 	timeFormat             = "2006-01-02T15-04-05.000000000Z"
+
+	printRateInterval = time.Second / 2
 )
 
 var (
@@ -606,7 +608,7 @@ func (pr *ProgressReader) printProgress() {
 	elapsed := now.Sub(pr.StartTime)
 	uploadSpeed := float64(pr.Current) / elapsed.Seconds()
 
-	if now.Sub(pr.LastPrinted) >= time.Second/2 { // print rate every second
+	if now.Sub(pr.LastPrinted) >= printRateInterval { // print rate every half second
 		progressStr := fmt.Sprintf("uploading progress: %.2f%% [ %s / %s ], rate: %s , cost ",
 			progress, getConvertSize(pr.Current), getConvertSize(pr.Total), getConvertRate(uploadSpeed))
 		// Clear current line
@@ -641,7 +643,7 @@ func (pw *ProgressWriter) printProgress() {
 	downloadedBytes := pw.Current
 	downloadSpeed := float64(downloadedBytes) / elapsed.Seconds()
 
-	if now.Sub(pw.LastPrinted) >= time.Second/2 { // print rate every second
+	if now.Sub(pw.LastPrinted) >= printRateInterval { // print rate every half second
 		fmt.Printf("\rdownloding progress: %.2f%% [ %s / %s ], rate: %s  ",
 			progress, getConvertSize(pw.Current), getConvertSize(pw.Total), getConvertRate(downloadSpeed))
 		pw.LastPrinted = now


### PR DESCRIPTION
### Description

1) if the actions contain object actions of bucket policy and need to apply to permission to all the objects in the bucket, the subresource needs to be set as "*"

2) fix policy cmd help info

### Rationale

fix bucket policy cmd

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...
