### PR TITLE
fix: fix upload print format

### DIFF
--- a/cmd/cmd_object.go
+++ b/cmd/cmd_object.go
@@ -325,9 +325,10 @@ func putObject(ctx *cli.Context) error {
 					return toCmdErr(err)
 				}
 
-				if err = uploadFile(bucketName, objectName, fileName, urlInfo, ctx, gnfdClient, false, false, objectSize); err != nil {
+				if err = uploadFile(bucketName, objectName, fileName, urlInfo, ctx, gnfdClient, false, true, objectSize); err != nil {
 					fmt.Println("upload object:", objectName, "err", err)
 				}
+				fmt.Println()
 			}
 		} else {
 			// upload single file

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -609,7 +609,7 @@ func (pr *ProgressReader) printProgress() {
 	uploadSpeed := float64(pr.Current) / elapsed.Seconds()
 
 	if now.Sub(pr.LastPrinted) >= printRateInterval { // print rate every half second
-		progressStr := fmt.Sprintf("uploading progress: %.2f%% [ %s / %s ], rate: %s , cost ",
+		progressStr := fmt.Sprintf("uploading progress: %.2f%% [ %s / %s ], rate: %s    ",
 			progress, getConvertSize(pr.Current), getConvertSize(pr.Total), getConvertRate(uploadSpeed))
 		// Clear current line
 		fmt.Print("\r", strings.Repeat(" ", len(pr.LastPrintedStr)), "\r")
@@ -644,7 +644,7 @@ func (pw *ProgressWriter) printProgress() {
 	downloadSpeed := float64(downloadedBytes) / elapsed.Seconds()
 
 	if now.Sub(pw.LastPrinted) >= printRateInterval { // print rate every half second
-		fmt.Printf("\rdownloding progress: %.2f%% [ %s / %s ], rate: %s  ",
+		fmt.Printf("\rdownloding progress: %.2f%% [ %s / %s ], rate: %s    ",
 			progress, getConvertSize(pw.Current), getConvertSize(pw.Total), getConvertRate(downloadSpeed))
 		pw.LastPrinted = now
 	}


### PR DESCRIPTION
### Description
fix upload print format

<img width="1259" alt="image" src="https://github.com/bnb-chain/greenfield-cmd/assets/19421226/780d088a-6f1e-4716-959d-a6c5c66d1274">
<img width="1268" alt="image" src="https://github.com/bnb-chain/greenfield-cmd/assets/19421226/14cc4902-52ab-4b71-a90c-3c021d868ee4">

### Rationale




### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...
