### PR TITLE
feat: support parsing content type when uploading files

### DIFF
--- a/cmd/cmd_object.go
+++ b/cmd/cmd_object.go
@@ -409,6 +409,12 @@ func uploadFile(bucketName, objectName, filePath, urlInfo string, ctx *cli.Conte
 	opts := sdktypes.CreateObjectOptions{}
 	if contentType != "" {
 		opts.ContentType = contentType
+	} else {
+		// parse the mimeType as content type
+		mimeType, err := getContentTypeOfFile(filePath)
+		if err == nil {
+			opts.ContentType = mimeType
+		}
 	}
 
 	visibity := ctx.Generic(visibilityFlag)


### PR DESCRIPTION
### Description

when uploading files, we can parse the mime type , and set the content type of the object as the mime type

### Rationale

set the accurate content type

### Example

upload a jpeg file , the content type has been set
<img width="1288" alt="image" src="https://github.com/bnb-chain/greenfield-cmd/assets/19421226/8126fdf7-a8fc-4a03-80bd-1ea292154620">


### Changes

Notable changes:
* add each change in a bullet point here
* ...
