### PR TITLE
fix: support automatically create folder structure when uploading folder

### DIFF
--- a/cmd/cmd_object.go
+++ b/cmd/cmd_object.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -379,6 +378,11 @@ func uploadFolder(urlInfo string, ctx *cli.Context,
 		if !info.IsDir() {
 			fileInfos = append(fileInfos, info)
 			filePaths = append(filePaths, path)
+		} else {
+			fmt.Println("creating folder:", path)
+			if createFolderErr := uploadFile(bucketName, path+"/", path, urlInfo, ctx, gnfdClient, true, false, 0); createFolderErr != nil {
+				return toCmdErr(createFolderErr)
+			}
 		}
 		return nil
 	})
@@ -388,9 +392,8 @@ func uploadFolder(urlInfo string, ctx *cli.Context,
 	}
 	// upload folder
 	for id, info := range fileInfos {
-		objectName := path.Base(filePaths[id])
-		if uploadErr := uploadFile(bucketName, objectName, filePaths[id], urlInfo, ctx, gnfdClient, false, false, info.Size()); uploadErr != nil {
-			fmt.Printf("failed to upload object: %s, error:%v \n", objectName, uploadErr)
+		if uploadErr := uploadFile(bucketName, filePaths[id], filePaths[id], urlInfo, ctx, gnfdClient, false, false, info.Size()); uploadErr != nil {
+			fmt.Printf("failed to upload object: %s, error:%v \n", filePaths[id], uploadErr)
 		}
 	}
 


### PR DESCRIPTION
### Description

support automatically create folders structure when uploading a local folder in a recursive way. The command will create empty files for the folders

### Rationale

it is reasonable to automatically create directory structure when upload the folder even the folder is a empty file

### Example

```
wayen@c02fvfsdmd6m testnet-test % tree test-dir9
test-dir9
├── hunter.jpeg9
├── test-dir88
└── test-dir89
    ├── download.log6
    └── download.log9

2 directories, 3 files
wayen@c02fvfsdmd6m testnet-test % ./gnfd-cmd object put --recursive test-dir9 gnfd://diiik1

Please enter the passphrase now:
creating folder: test-dir9
creating folder: test-dir9/test-dir88
creating folder: test-dir9/test-dir89
uploading progress: 100.00% [ 15.70K / 15.70K ], rate: 13.49 KB/s
sealing...
upload test-dir9/hunter.jpeg9 to gnfd://diiik1
uploading progress: 100.00% [ 39.38K / 39.38K ], rate: 34.17 KB/s
sealing...
upload test-dir9/test-dir89/download.log6 to gnfd://diiik1
uploading progress: 100.00% [ 174.97K / 174.97K ], rate: 152.71 KB/s
sealing...
upload test-dir9/test-dir89/download.log9 to gnfd://diiik1

wayen@c02fvfsdmd6m testnet-test % ./gnfd-cmd object ls --recursive  gnfd://diiik1/test-dir9
Please enter the passphrase now:
2023-11-20 18:12:45               0 test-dir9/
2023-11-20 17:17:32         1110920 test-dir9/download.log90
2023-11-20 18:13:01           16077 test-dir9/hunter.jpeg9
2023-11-20 18:12:51               0 test-dir9/test-dir88/
2023-11-20 18:12:56               0 test-dir9/test-dir89/
2023-11-20 18:13:11           40330 test-dir9/test-dir89/download.log6
2023-11-20 18:13:22          179167 test-dir9/test-dir89/download.log9
```

### Changes

Notable changes:
* add each change in a bullet point here
* ...
