### PR TITLE
feat: batch upload

### DIFF
--- a/cmd/cmd_task.go
+++ b/cmd/cmd_task.go
@@ -110,10 +110,13 @@ func retryTask(ctx *cli.Context) error {
 	if err != nil {
 		return toCmdErr(err)
 	}
-	gnfdClient, err := NewClient(ctx, false)
+	gnfdClient, err := NewClient(ctx, ClientOptions{IsQueryCmd: true})
 	if err != nil {
 		return err
 	}
+	fmt.Printf("task: %s\n", content.TaskID)
+	fmt.Printf("folder name: %s\n", content.FolderName)
+	fmt.Println("retrying...")
 	return uploadFolderByTask(ctx, homeDir, gnfdClient, content)
 }
 

--- a/cmd/cmd_task.go
+++ b/cmd/cmd_task.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+)
+
+func cmdTaskStatus() *cli.Command {
+	return &cli.Command{
+		Name:      "status",
+		Action:    getTaskStatus,
+		Usage:     "get task status by task id",
+		ArgsUsage: "",
+		Description: `
+Examples:
+$ gnfd-cmd task status --taskId 123`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     taskIDFlag,
+				Value:    "",
+				Usage:    "task id",
+				Required: true,
+			},
+		},
+	}
+}
+
+func cmdTaskDelete() *cli.Command {
+	return &cli.Command{
+		Name:      "delete",
+		Action:    deleteTask,
+		Usage:     "delete task by id",
+		ArgsUsage: "",
+		Description: `
+Examples:
+$ gnfd-cmd task delete --taskId 123 `,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     taskIDFlag,
+				Value:    "",
+				Usage:    "task id",
+				Required: true,
+			},
+		},
+	}
+}
+
+func cmdTaskRetry() *cli.Command {
+	return &cli.Command{
+		Name:      "retry",
+		Action:    retryTask,
+		Usage:     "retry task by id",
+		ArgsUsage: "",
+		Description: `
+Examples:
+$ gnfd-cmd task retry --taskId 123 `,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     taskIDFlag,
+				Value:    "",
+				Usage:    "task id",
+				Required: true,
+			},
+		},
+	}
+}
+
+func getTaskStatus(ctx *cli.Context) error {
+	content, err := getTaskState(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Folder: %s\n", content.FolderName)
+	fmt.Printf("Status: %s\n", content.Status)
+	for _, state := range content.ObjectState {
+		fmt.Printf("%s\n", fmt.Sprintf("%s %s %s", state.Status, state.ObjectName, state.Comment))
+	}
+	fmt.Println()
+	return nil
+}
+
+func deleteTask(ctx *cli.Context) error {
+	taskID := ctx.String(taskIDFlag)
+	homeDir, err := getHomeDir(ctx)
+	if err != nil {
+		return toCmdErr(err)
+	}
+	taskFileName := fmt.Sprintf("/.%s", taskID)
+	taskFilePath := filepath.Join(homeDir, taskFileName)
+	if !fileExists(taskFilePath) {
+		return toCmdErr(fmt.Errorf("task not found"))
+	}
+	err = os.RemoveAll(taskFilePath)
+	if err != nil {
+		return toCmdErr(err)
+	}
+	return nil
+}
+
+func retryTask(ctx *cli.Context) error {
+	content, err := getTaskState(ctx)
+	if err != nil {
+		return err
+	}
+	homeDir, err := getHomeDir(ctx)
+	if err != nil {
+		return toCmdErr(err)
+	}
+	gnfdClient, err := NewClient(ctx, false)
+	if err != nil {
+		return err
+	}
+	return uploadFolderByTask(ctx, homeDir, gnfdClient, content)
+}
+
+func getTaskState(ctx *cli.Context) (*TaskState, error) {
+	taskID := ctx.String(taskIDFlag)
+	homeDir, err := getHomeDir(ctx)
+	if err != nil {
+		return nil, toCmdErr(err)
+	}
+	taskFileName := fmt.Sprintf("/.%s/state", taskID)
+	taskFilePath := filepath.Join(homeDir, taskFileName)
+	if !fileExists(taskFilePath) {
+		return nil, toCmdErr(fmt.Errorf("task not found"))
+	}
+	value, err := readFile(taskFilePath)
+	if err != nil {
+		return nil, toCmdErr(err)
+	}
+	var content TaskState
+	err = json.Unmarshal(value, &content)
+	if err != nil {
+		return nil, toCmdErr(err)
+	}
+	return &content, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path) //os.Stat获取文件信息
+	return !os.IsNotExist(err)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -162,7 +162,6 @@ func main() {
 					cmdGetQuotaPrice(),
 				},
 			},
-
 			{
 				Name:  "account",
 				Usage: "support the keystore operation functions",
@@ -172,6 +171,15 @@ func main() {
 					cmdCreateAccount(),
 					cmdExportAccount(),
 					cmdSetDefaultAccount(),
+				},
+			},
+			{
+				Name:  "task",
+				Usage: "support the batch upload file",
+				Subcommands: []*cli.Command{
+					cmdTaskStatus(),
+					cmdTaskDelete(),
+					cmdTaskRetry(),
 				},
 			},
 			cmdShowVersion(),

--- a/cmd/routine_pool.go
+++ b/cmd/routine_pool.go
@@ -1,0 +1,38 @@
+package main
+
+import "sync"
+
+// Pool goroutine Pool
+type Pool struct {
+	queue chan int
+	wg    *sync.WaitGroup
+}
+
+func NewPool(size int) *Pool {
+	if size <= 0 {
+		size = 1
+	}
+	return &Pool{
+		queue: make(chan int, size),
+		wg:    &sync.WaitGroup{},
+	}
+}
+
+func (p *Pool) Add(delta int) {
+	for i := 0; i < delta; i++ {
+		p.queue <- 1
+	}
+	for i := 0; i > delta; i-- {
+		<-p.queue
+	}
+	p.wg.Add(delta)
+}
+
+func (p *Pool) Done() {
+	<-p.queue
+	p.wg.Done()
+}
+
+func (p *Pool) Wait() {
+	p.wg.Wait()
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -800,7 +800,6 @@ func createAndWriteFile(fileName string, content []byte) error {
 		return toCmdErr(errors.New("failed to create directory %s" + filepath.Dir(fileName)))
 	}
 
-	// store the keystore file
 	if err := os.WriteFile(fileName, content, 0600); err != nil {
 		return toCmdErr(fmt.Errorf("failed to write keyfile to the path%s: %v", fileName, err))
 	}
@@ -816,6 +815,14 @@ func readFile(fileName string) ([]byte, error) {
 	return content, nil
 }
 
+type UploadFlag struct {
+	ContentType string                      `json:"content_type"`
+	SecondarySP string                      `json:"secondary_sp"`
+	PartSize    uint64                      `json:"part_size"`
+	Tags        string                      `json:"tags"`
+	Visibility  storageTypes.VisibilityType `json:"visibility"`
+}
+
 type TaskState struct {
 	Lock        *sync.Mutex
 	ObjectState map[int]*UploadTaskObject `json:"object_state"`
@@ -823,6 +830,7 @@ type TaskState struct {
 	Status      string                    `json:"status"`
 	BucketName  string                    `json:"bucket_name"`
 	FolderName  string                    `json:"folder_name"`
+	Flag        UploadFlag                `json:"flag"`
 }
 
 type UploadTaskObject struct {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -64,6 +65,7 @@ const (
 	expireTimeFlag          = "expire"
 	IdFlag                  = "id"
 	DestChainIdFlag         = "destChainId"
+	taskIDFlag              = "taskId"
 
 	ownerAddressFlag = "owner"
 	addressFlag      = "address"
@@ -125,6 +127,15 @@ const (
 	printRateInterval  = time.Second / 2
 	bytesToReadForMIME = 512
 	notFound           = -1
+
+	TaskStatusCreate  = "created"
+	TaskStatusFail    = "failed"
+	TaskStatusSuccess = "successful"
+
+	TaskObjectStatusWaitForUpload = "wait_for_upload"
+	TaskObjectStatusCreated       = "created"
+	TaskObjectStatusSeal          = "sealed"
+	TaskObjectStatusFailed        = "failed"
 )
 
 var (
@@ -782,4 +793,54 @@ func getContentTypeOfFile(filePath string) (string, error) {
 
 	contentType := http.DetectContentType(buffer)
 	return contentType, nil
+}
+
+func createAndWriteFile(fileName string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(fileName), 0700); err != nil {
+		return toCmdErr(errors.New("failed to create directory %s" + filepath.Dir(fileName)))
+	}
+
+	// store the keystore file
+	if err := os.WriteFile(fileName, content, 0600); err != nil {
+		return toCmdErr(fmt.Errorf("failed to write keyfile to the path%s: %v", fileName, err))
+	}
+	return nil
+}
+
+func readFile(fileName string) ([]byte, error) {
+	content, err := os.ReadFile(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the keyfile at '%s': %v \n", fileName, err)
+	}
+
+	return content, nil
+}
+
+type TaskState struct {
+	Lock        *sync.Mutex
+	ObjectState map[int]*UploadTaskObject `json:"object_state"`
+	TaskID      string                    `json:"task_id"`
+	Status      string                    `json:"status"`
+	BucketName  string                    `json:"bucket_name"`
+	FolderName  string                    `json:"folder_name"`
+}
+
+type UploadTaskObject struct {
+	BucketName         string `json:"bucket_name"`
+	ObjectName         string `json:"object_name"`
+	FilePath           string `json:"file_path"`
+	UploadSingleFolder bool   `json:"upload_single_folder"`
+	ObjectSize         int64  `json:"object_size"`
+	Status             string `json:"status"`
+	Comment            string `json:"comment"`
+}
+
+func (t *TaskState) UpdateObjectState(index int, status, comment string) {
+	_, ok := t.ObjectState[index]
+	if ok {
+		t.Lock.Lock()
+		t.ObjectState[index].Status = status
+		t.ObjectState[index].Comment = comment
+		t.Lock.Unlock()
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ require (
 	cosmossdk.io/math v1.0.1
 	github.com/BurntSushi/toml v1.3.2
 	github.com/bnb-chain/greenfield v1.2.1-0.20231221015040-11071a6ee95b
-	github.com/bnb-chain/greenfield-go-sdk v1.1.2-0.20240117023028-b234c71d31cb
+	github.com/bnb-chain/greenfield-go-sdk v1.1.2-0.20240118034134-fcbe7c46d22b
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/ethereum/go-ethereum v1.10.26
+	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.29.1
 	github.com/urfave/cli/v2 v2.10.2
 	golang.org/x/term v0.13.0
@@ -67,7 +68,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20231206043955-0855e0965bc
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20231206043955-0855e0965bc8/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20231206043955-0855e0965bc8 h1:1Ud7itq03c4Q9h0kBpw1FYlWKN3kco8cgj59vdd50UQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20231206043955-0855e0965bc8/go.mod h1:An0MllWJY6PxibUpnwGk8jOm+a/qIxlKmL5Zyp9NnaM=
-github.com/bnb-chain/greenfield-go-sdk v1.1.2-0.20240117023028-b234c71d31cb h1:uAlMnPdtCNvHsVAP4ECagKPuLVNTYqsEuCJp+XlYOMI=
-github.com/bnb-chain/greenfield-go-sdk v1.1.2-0.20240117023028-b234c71d31cb/go.mod h1:LROoeU9nirW2Z5Wh7Oo3mww2vC3D0Zz9rMHOobf8LuE=
+github.com/bnb-chain/greenfield-go-sdk v1.1.2-0.20240118034134-fcbe7c46d22b h1:1W0W5YPyGAFPCeJBVbi9fvLN+yYQhu4SYAo9RBTRFa0=
+github.com/bnb-chain/greenfield-go-sdk v1.1.2-0.20240118034134-fcbe7c46d22b/go.mod h1:LROoeU9nirW2Z5Wh7Oo3mww2vC3D0Zz9rMHOobf8LuE=
 github.com/bnb-chain/greenfield-iavl v0.20.1 h1:y3L64GU99otNp27/xLVBTDbv4eroR6CzoYz0rbaVotM=
 github.com/bnb-chain/greenfield-iavl v0.20.1/go.mod h1:oLksTs8dfh7DYIKBro7hbRQ+ewls7ghJ27pIXlbEXyI=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=


### PR DESCRIPTION
Description
Supports batch file upload

Rationale
Recursively uploading files requires management/viewing progress, as well as retry capabilities

Example
./build/gnfd-cmd --home ./ bucket create gnfd://constwz5
./build/gnfd-cmd --home ./ object put --recursive ~/Desktop/t-folder gnfd://constwz5
./build/gnfd-cmd --home ./ task status --taskId 193977d7-93b1-48d3-ad83-cf2faf9feeb2
./build/gnfd-cmd --home ./ task retry --taskId 735b85cd-251c-4f73-a81e-7c60da2bf3fd
./build/gnfd-cmd --home ./ task delete --taskId 034b5786-bb62-4620-a145-c2de9a1e70f6

Changes
Notable changes:

Refactored the code uploaded by recursive
Added task subcmd