### PR TITLE
fix: task gnfd-client

### DIFF
--- a/cmd/cmd_task.go
+++ b/cmd/cmd_task.go
@@ -110,7 +110,7 @@ func retryTask(ctx *cli.Context) error {
 	if err != nil {
 		return toCmdErr(err)
 	}
-	gnfdClient, err := NewClient(ctx, ClientOptions{IsQueryCmd: true})
+	gnfdClient, err := NewClient(ctx, ClientOptions{IsQueryCmd: false})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

fix mis-typed boolean

### Rationale
Upload object shall use an account, therefore IsQueryCmd shall set to false

### Example
N/A

### Changes

Notable changes:
* batch upload