### PR TITLE
fix: some lint problems and import issue

### DIFF
--- a/cmd/client_gnfd.go
+++ b/cmd/client_gnfd.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bnb-chain/greenfield-go-sdk/client"
 	"github.com/bnb-chain/greenfield-go-sdk/types"
-	sdktypes "github.com/bnb-chain/greenfield-go-sdk/types"
 	"github.com/urfave/cli/v2"
 )
 
@@ -47,7 +46,7 @@ func NewClient(ctx *cli.Context, opts ClientOptions) (client.IClient, error) {
 			return nil, err
 		}
 
-		account, err = sdktypes.NewAccountFromPrivateKey("gnfd-account", privateKey)
+		account, err = types.NewAccountFromPrivateKey("gnfd-account", privateKey)
 		if err != nil {
 			fmt.Println("new account err", err.Error())
 			return nil, err

--- a/cmd/cmd_account.go
+++ b/cmd/cmd_account.go
@@ -320,7 +320,7 @@ func listKeyStore(keystoreDir, defaultAccount string) error {
 			keyPath := filepath.Join(keystoreDir, file.Name())
 			keyFileContent, err = os.ReadFile(keyPath)
 			if err != nil {
-				return fmt.Errorf("failed to read the keyfile at '%s': %v \n", keyPath, err)
+				return fmt.Errorf("failed to read the keyfile at '%s': %v", keyPath, err)
 			}
 
 			k := new(encryptedKey)
@@ -545,7 +545,7 @@ func parseKeystore(ctx *cli.Context) (string, string, error) {
 
 	privateKey, err := DecryptKey(keyjson, password)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to decrypting key: %v \n", err)
+		return "", "", fmt.Errorf("failed to decrypting key: %v", err)
 	}
 
 	return privateKey, keyFile, nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -465,7 +465,7 @@ func loadKey(file string) (string, sdk.AccAddress, error) {
 	}
 
 	if len(priBytes) != 32 {
-		return "", nil, fmt.Errorf("Len of Keybytes is not equal to 32 ")
+		return "", nil, fmt.Errorf("len of Keybytes is not equal to 32 ")
 	}
 	var keyBytesArray [32]byte
 	copy(keyBytesArray[:], priBytes[:32])
@@ -583,7 +583,7 @@ func loadKeyStoreFile(ctx *cli.Context) ([]byte, string, error) {
 	// fetch private key from keystore
 	content, err := os.ReadFile(keyfilePath)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to read the keyfile at '%s': %v \n", keyfilePath, err)
+		return nil, "", fmt.Errorf("failed to read the keyfile at '%s': %v", keyfilePath, err)
 	}
 
 	return content, keyfilePath, nil
@@ -759,7 +759,7 @@ func checkIfDownloadFileExist(filePath, objectName string) (string, error) {
 			filePath = filePath + "/" + objectName
 			return filePath, nil
 		}
-		return filePath, fmt.Errorf("download file:%s already exist\n", filePath)
+		return filePath, fmt.Errorf("download file:%s already exist", filePath)
 	}
 	return filePath, nil
 }
@@ -810,7 +810,7 @@ func createAndWriteFile(fileName string, content []byte) error {
 func readFile(fileName string) ([]byte, error) {
 	content, err := os.ReadFile(fileName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read the keyfile at '%s': %v \n", fileName, err)
+		return nil, fmt.Errorf("failed to read the keyfile at '%s': %v", fileName, err)
 	}
 
 	return content, nil


### PR DESCRIPTION
1. fix lint error: error strings should not end with punctuation or newlines (ST1005)
2. import github.com/bnb-chain/greenfield-go-sdk/types twice in files.